### PR TITLE
docs: fix typo in README.md for HotToastConfig Import

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ bootstrapApplication(AppComponent, {
 Add `provideHotToastConfig()` to your app.module.ts `providers` section. Toast options ([`Partial<ToastConfig>`](#toastconfig)) here.:
 
 ```typescript
-import { providerHotToastConfig } from '@ngxpert/hot-toast';
+import { provideHotToastConfig } from '@ngxpert/hot-toast';
 
 @NgModule({
   providers: [provideHotToastConfig()],


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
A typo exists in the README.md where provideHotToastConfig is mistakenly written as providerHotToastConfig.

Issue Number: N/A


## What is the new behavior?
The typo has been corrected to provideHotToastConfig. 

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
No additional changes were made beyond fixing the typo.