### PR TITLE
refactor: tree-shake JIT related stuff

### DIFF
--- a/projects/ngxpert/hot-toast/src/lib/components/hot-toast-group-item/hot-toast-group-item.component.html
+++ b/projects/ngxpert/hot-toast/src/lib/components/hot-toast-group-item/hot-toast-group-item.component.html
@@ -1,7 +1,7 @@
 <div
   class="hot-toast-bar-base-container"
-  [ngStyle]="containerPositionStyle"
-  [ngClass]="'hot-toast-theme-' + toast.theme"
+  [style]="containerPositionStyle"
+  [class]="'hot-toast-theme-' + toast.theme"
   [style.--hot-toast-scale]="scale"
   [style.--hot-toast-translate-y]="translateY"
 >
@@ -9,8 +9,8 @@
     <div
       class="hot-toast-bar-base"
       #hotToastBarBase
-      [ngStyle]="toastBarBaseStylesSignal()"
-      [ngClass]="toast.className"
+      [style]="toastBarBaseStylesSignal()"
+      [class]="toast.className"
       [style.--hot-toast-animation-state]="isManualClose ? 'running' : 'paused'"
       [style.--hot-toast-exit-animation-state]="isShowingAllToasts ? 'paused' : 'running'"
       [style.--hot-toast-exit-animation-delay]="exitAnimationDelay"
@@ -37,7 +37,7 @@
         type="button"
         class="hot-toast-close-btn"
         aria-label="Close"
-        [ngStyle]="toast.closeStyle"
+        [style]="toast.closeStyle"
       ></button>
       }
     </div>

--- a/projects/ngxpert/hot-toast/src/lib/components/hot-toast-group-item/hot-toast-group-item.component.ts
+++ b/projects/ngxpert/hot-toast/src/lib/components/hot-toast-group-item/hot-toast-group-item.component.ts
@@ -18,7 +18,6 @@ import {
   ChangeDetectorRef,
   inject,
 } from '@angular/core';
-import { NgClass, NgStyle } from '@angular/common';
 import { AnimatedIconComponent } from '../animated-icon/animated-icon.component';
 import { IndicatorComponent } from '../indicator/indicator.component';
 import { DynamicViewDirective, isComponent, isTemplateRef } from '@ngneat/overview';
@@ -28,10 +27,10 @@ import { Toast, ToastConfig, CreateHotToastRef, HotToastClose, HotToastGroupEven
 import { animate } from '../../utils';
 
 @Component({
-    selector: 'hot-toast-group-item',
-    templateUrl: 'hot-toast-group-item.component.html',
-    changeDetection: ChangeDetectionStrategy.OnPush,
-    imports: [NgClass, NgStyle, AnimatedIconComponent, IndicatorComponent, DynamicViewDirective]
+  selector: 'hot-toast-group-item',
+  templateUrl: 'hot-toast-group-item.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [AnimatedIconComponent, IndicatorComponent, DynamicViewDirective],
 })
 export class HotToastGroupItemComponent implements OnChanges, OnInit, AfterViewInit, OnDestroy {
   private _toast: Toast<unknown>;

--- a/projects/ngxpert/hot-toast/src/lib/components/hot-toast/hot-toast.component.html
+++ b/projects/ngxpert/hot-toast/src/lib/components/hot-toast/hot-toast.component.html
@@ -1,7 +1,7 @@
 <div
   class="hot-toast-bar-base-container"
-  [ngStyle]="containerPositionStyle"
-  [ngClass]="'hot-toast-theme-' + toast.theme"
+  [style]="containerPositionStyle"
+  [class]="'hot-toast-theme-' + toast.theme"
   [style.--hot-toast-scale]="scale"
   [style.--hot-toast-translate-y]="translateY"
 >
@@ -14,8 +14,8 @@
     <div
       class="hot-toast-bar-base"
       #hotToastBarBase
-      [ngStyle]="toastBarBaseStylesSignal()"
-      [ngClass]="toast.className"
+      [style]="toastBarBaseStylesSignal()"
+      [class]="toast.className"
       [style.--hot-toast-animation-state]="isManualClose ? 'running' : 'paused'"
       [style.--hot-toast-exit-animation-state]="isShowingAllToasts ? 'paused' : 'running'"
       [style.--hot-toast-exit-animation-delay]="exitAnimationDelay"
@@ -45,7 +45,7 @@
         class="hot-toast-group-btn"
         [class.expanded]="isExpanded"
         [attr.aria-label]="isExpanded ? 'Collapse' : 'Expand'"
-        [ngStyle]="toast.group.btnStyle"
+        [style]="toast.group.btnStyle"
       ></button>
       } @if (toast.dismissible) {
       <button
@@ -53,7 +53,7 @@
         type="button"
         class="hot-toast-close-btn"
         aria-label="Close"
-        [ngStyle]="toast.closeStyle"
+        [style]="toast.closeStyle"
       ></button>
       }
     </div>
@@ -62,7 +62,7 @@
     <div
       role="list"
       class="hot-toast-bar-base-group"
-      [ngClass]="toast.group?.className"
+      [class]="toast.group?.className"
       [style.--hot-toast-group-height]="groupHeight + 'px'"
     >
       @for (item of groupChildrenToasts; track item.id) {

--- a/projects/ngxpert/hot-toast/src/lib/components/hot-toast/hot-toast.component.ts
+++ b/projects/ngxpert/hot-toast/src/lib/components/hot-toast/hot-toast.component.ts
@@ -19,7 +19,6 @@ import {
   SimpleChanges,
   ViewChild,
 } from '@angular/core';
-import { CommonModule } from '@angular/common';
 import { DynamicViewDirective, isComponent, isTemplateRef } from '@ngneat/overview';
 
 import { ENTER_ANIMATION_DURATION, EXIT_ANIMATION_DURATION, HOT_TOAST_DEPTH_SCALE } from '../../constants';
@@ -34,7 +33,7 @@ import { HotToastGroupItemComponent } from '../hot-toast-group-item/hot-toast-gr
   selector: 'hot-toast',
   templateUrl: 'hot-toast.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [CommonModule, DynamicViewDirective, IndicatorComponent, AnimatedIconComponent, HotToastGroupItemComponent],
+  imports: [DynamicViewDirective, IndicatorComponent, AnimatedIconComponent, HotToastGroupItemComponent],
 })
 export class HotToastComponent implements OnInit, AfterViewInit, OnDestroy, OnChanges, DoCheck {
   private _toast: Toast<unknown>;
@@ -54,7 +53,7 @@ export class HotToastComponent implements OnInit, AfterViewInit, OnDestroy, OnCh
       } ${ENTER_ANIMATION_DURATION}ms cubic-bezier(0.21, 1.02, 0.73, 1) forwards`;
       newStyle['animation'] = enterAnimation;
     }
-    
+
     this.toastBarBaseStylesSignal.set(newStyle);
   }
   get toast() {

--- a/projects/ngxpert/hot-toast/src/lib/components/indicator/icons/loader/loader.component.html
+++ b/projects/ngxpert/hot-toast/src/lib/components/indicator/icons/loader/loader.component.html
@@ -1,4 +1,5 @@
 <div
   class="hot-toast-loader-icon"
-  [ngStyle]="{ 'border-color': theme?.primary, 'border-right-color': theme?.secondary }"
+  [style.border-color]="theme?.primary"
+  [style.border-right-color]="theme?.secondary"
 ></div>

--- a/projects/ngxpert/hot-toast/src/lib/components/indicator/icons/loader/loader.component.ts
+++ b/projects/ngxpert/hot-toast/src/lib/components/indicator/icons/loader/loader.component.ts
@@ -1,13 +1,11 @@
 import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
-import { CommonModule } from '@angular/common';
 
 import { IconTheme } from '../../../../hot-toast.model';
 
 @Component({
-    selector: 'hot-toast-loader',
-    templateUrl: './loader.component.html',
-    changeDetection: ChangeDetectionStrategy.OnPush,
-    imports: [CommonModule]
+  selector: 'hot-toast-loader',
+  templateUrl: './loader.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class LoaderComponent {
   @Input() theme: IconTheme;

--- a/projects/ngxpert/hot-toast/src/lib/hot-toast.model.ts
+++ b/projects/ngxpert/hot-toast/src/lib/hot-toast.model.ts
@@ -1,4 +1,4 @@
-import { Component, Injector } from '@angular/core';
+import { Injector } from '@angular/core';
 import { Content } from '@ngneat/overview';
 import { Observable } from 'rxjs';
 
@@ -69,9 +69,9 @@ const isFunction = <TValue, TArg>(
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const isAngularComponent = (arg: any): boolean => {
-  return (
-    typeof arg === 'function' && arg.decorators && arg.decorators.some((decorator) => decorator.type === Component)
-  );
+  // `ɵcmp` is a component definition set by the Angular compiler.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return typeof arg === 'function' && !!(arg as any).ɵcmp;
 };
 
 export const resolveValueOrFunction = <TValue, TArg>(valOrFunction: ValueOrFunction<TValue, TArg>, arg: TArg): TValue =>


### PR DESCRIPTION
In this commit, we remove the reference to the `Component` function exported by Angular because it pulls in JIT-related code like the `compileComponent` function, which increases the final bundle size by around 100KB.

Decorators are never preserved in the production bundle, as they are always replaced with component definitions.