### PR TITLE
fix: track rAF to cancel them after hosting component gets destroyed

### DIFF
--- a/projects/ngxpert/hot-toast/src/lib/components/hot-toast-group-item/hot-toast-group-item.component.ts
+++ b/projects/ngxpert/hot-toast/src/lib/components/hot-toast-group-item/hot-toast-group-item.component.ts
@@ -85,6 +85,8 @@ export class HotToastGroupItemComponent implements OnChanges, OnInit, AfterViewI
   toastBarBaseStylesSignal = signal({});
 
   private unlisteners: VoidFunction[] = [];
+  private rafIds: number[] = [];
+  private destroyed = false;
   protected softClosed = false;
 
   private injector = inject(Injector);
@@ -163,9 +165,12 @@ export class HotToastGroupItemComponent implements OnChanges, OnInit, AfterViewI
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes.toast && !changes.toast.firstChange && changes.toast.currentValue?.message) {
-      requestAnimationFrame(() => {
+      const rafId = requestAnimationFrame(() => {
+        this.rafIds = this.rafIds.filter((id) => id !== rafId);
+        if (this.destroyed) return;
         this.height.emit(this.toastBarBase.nativeElement.offsetHeight);
       });
+      this.rafIds.push(rafId);
     }
   }
 
@@ -223,9 +228,12 @@ export class HotToastGroupItemComponent implements OnChanges, OnInit, AfterViewI
     const nativeElement = this.toastBarBase.nativeElement;
     // Caretaker note: accessing `offsetHeight` triggers the whole layout update.
     // Macro tasks (like `setTimeout`) might be executed within the current rendering frame and cause a frame drop.
-    requestAnimationFrame(() => {
+    const rafId = requestAnimationFrame(() => {
+      this.rafIds = this.rafIds.filter((id) => id !== rafId);
+      if (this.destroyed) return;
       this.height.emit(nativeElement.offsetHeight);
     });
+    this.rafIds.push(rafId);
 
     this.setToastAttributes();
   }
@@ -269,6 +277,10 @@ export class HotToastGroupItemComponent implements OnChanges, OnInit, AfterViewI
   }
 
   ngOnDestroy() {
+    this.destroyed = true;
+    while (this.rafIds.length) {
+      cancelAnimationFrame(this.rafIds.pop());
+    }
     this.close();
     while (this.unlisteners.length) {
       this.unlisteners.pop()();

--- a/projects/ngxpert/hot-toast/src/lib/components/hot-toast/hot-toast.component.ts
+++ b/projects/ngxpert/hot-toast/src/lib/components/hot-toast/hot-toast.component.ts
@@ -103,6 +103,8 @@ export class HotToastComponent implements OnInit, AfterViewInit, OnDestroy, OnCh
   toastBarBaseStylesSignal = signal<Record<string, string>>({});
 
   private unlisteners: VoidFunction[] = [];
+  private rafIds: number[] = [];
+  private destroyed = false;
   private softClosed = false;
   private groupRefs: CreateHotToastRef<unknown>[] = [];
 
@@ -261,9 +263,12 @@ export class HotToastComponent implements OnInit, AfterViewInit, OnDestroy, OnCh
     const nativeElement = this.toastBarBase.nativeElement;
     // Caretaker note: accessing `offsetHeight` triggers the whole layout update.
     // Macro tasks (like `setTimeout`) might be executed within the current rendering frame and cause a frame drop.
-    requestAnimationFrame(() => {
+    const rafId = requestAnimationFrame(() => {
+      this.rafIds = this.rafIds.filter((id) => id !== rafId);
+      if (this.destroyed) return;
       this.height.emit(nativeElement.offsetHeight);
     });
+    this.rafIds.push(rafId);
 
     this.setToastAttributes();
   }
@@ -313,6 +318,10 @@ export class HotToastComponent implements OnInit, AfterViewInit, OnDestroy, OnCh
   }
 
   ngOnDestroy() {
+    this.destroyed = true;
+    while (this.rafIds.length) {
+      cancelAnimationFrame(this.rafIds.pop());
+    }
     this.close();
     while (this.unlisteners.length) {
       this.unlisteners.pop()();
@@ -384,13 +393,19 @@ export class HotToastComponent implements OnInit, AfterViewInit, OnDestroy, OnCh
 
   private emiHeightWithGroup(isExpanded: boolean) {
     if (isExpanded) {
-      requestAnimationFrame(() => {
+      const rafId = requestAnimationFrame(() => {
+        this.rafIds = this.rafIds.filter((id) => id !== rafId);
+        if (this.destroyed) return;
         this.height.emit(this.toastBarBase.nativeElement.offsetHeight + this.groupHeight);
       });
+      this.rafIds.push(rafId);
     } else {
-      requestAnimationFrame(() => {
+      const rafId = requestAnimationFrame(() => {
+        this.rafIds = this.rafIds.filter((id) => id !== rafId);
+        if (this.destroyed) return;
         this.height.emit(this.toastBarBase.nativeElement.offsetHeight);
       });
+      this.rafIds.push(rafId);
     }
   }
 }


### PR DESCRIPTION
After teardown the rAF calls are still being executed and are trying to emit on the height output of the component, to stop them from emitting after teardown, a id tracking was introduced to close them.

fix #194

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: [CONTRIBUTING.md](./CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

This commit introduces `rAF` id tracking to cancel them in case a frame is still emitting after destroying the hosting component that uses the service.

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

While testing my code alot of warnings get printed about a output that is still being emitted even though the component was already torn down.

`NG0953: Unexpected emit for destroyed OutputRef. The owning directive/component is destroyed.` 

Issue Number: #194

## What is the new behavior?

Request Animation Frames will be tracked by their id, and will be canceled on `ngOnDestroy` to stop the `rAF` from emitting anymore.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

None