### PR TITLE
fix: pause dismiss timer on focus-within, not just focus (#199)

### DIFF
--- a/projects/ngxpert/hot-toast/src/styles/components/_hot-toast.scss
+++ b/projects/ngxpert/hot-toast/src/styles/components/_hot-toast.scss
@@ -17,6 +17,7 @@
   // will-change: var(--hot-toast-will-change, transform);
 
   &:hover,
+  &:focus,
   &:focus-within {
     animation-play-state: var(--hot-toast-animation-state, paused) !important;
   }

--- a/projects/ngxpert/hot-toast/src/styles/components/_hot-toast.scss
+++ b/projects/ngxpert/hot-toast/src/styles/components/_hot-toast.scss
@@ -17,7 +17,7 @@
   // will-change: var(--hot-toast-will-change, transform);
 
   &:hover,
-  &:focus {
+  &:focus-within {
     animation-play-state: var(--hot-toast-animation-state, paused) !important;
   }
 


### PR DESCRIPTION
Fixes #199.

### Problem

The dismiss countdown pauses on hover but not when a control inside the toast receives keyboard focus, so a toast can dismiss itself while a keyboard or screen-reader user is reaching its close button (or an action inside a component toast).

`_hot-toast.scss` already intends to cover this — it pauses on `:focus`:

```scss
&:hover,
&:focus {
  animation-play-state: var(--hot-toast-animation-state, paused) !important;
}
```

But that selector can't match in practice. `.hot-toast-bar-base` is a plain `<div>` with no `tabindex`, so it isn't focusable, and `:focus` matches **only the focused element itself** — never an ancestor. Focusing the close button (`.hot-toast-close-btn`, the only focusable element in a default toast) leaves the exit animation running.

### Change

One line: `:focus` → `:focus-within`, which matches an ancestor of the focused element. The close button's own `:focus` rule (its box-shadow/outline, further down the file) is untouched.

### Verification

Patched this exact rule in an application stylesheet and confirmed `getComputedStyle(document.querySelector('.hot-toast-bar-base')).animationPlayState` goes `running → paused → running` as focus enters and leaves the toast. Hover behaviour is unchanged (the `:hover` half of the selector is intact).

### Why it matters

The docs recommend `autoClose: false` for toasts with an action, "to accommodate screen-reader users". With `:focus-within`, an auto-closing action toast (e.g. an undo prompt, where the time limit is intrinsic) stays open while a keyboard user interacts with it — the pause-to-extend behaviour WCAG 2.2.1 asks for, currently available to mouse users only.


Thank you for the work with maintaining hot-toast @shhdharmen, great job! 😊
