### PR TITLE
feat: make close button aria-label configurable (#200)

### DIFF
--- a/projects/ngxpert/hot-toast/src/lib/components/hot-toast-group-item/hot-toast-group-item.component.html
+++ b/projects/ngxpert/hot-toast/src/lib/components/hot-toast-group-item/hot-toast-group-item.component.html
@@ -36,7 +36,7 @@
         (click)="close()"
         type="button"
         class="hot-toast-close-btn"
-        aria-label="Close"
+        [attr.aria-label]="toast.closeLabel"
         [style]="toast.closeStyle"
       ></button>
       }

--- a/projects/ngxpert/hot-toast/src/lib/components/hot-toast/hot-toast.component.html
+++ b/projects/ngxpert/hot-toast/src/lib/components/hot-toast/hot-toast.component.html
@@ -52,7 +52,7 @@
         (click)="close()"
         type="button"
         class="hot-toast-close-btn"
-        aria-label="Close"
+        [attr.aria-label]="toast.closeLabel"
         [style]="toast.closeStyle"
       ></button>
       }

--- a/projects/ngxpert/hot-toast/src/lib/hot-toast.model.ts
+++ b/projects/ngxpert/hot-toast/src/lib/hot-toast.model.ts
@@ -33,6 +33,7 @@ export class ToastConfig implements DefaultToastOptions {
   position: ToastPosition = 'top-center';
   className: string;
   closeStyle: Record<string, string>;
+  closeLabel = 'Close';
   dismissible: boolean;
   autoClose = true;
   duration: number;
@@ -194,6 +195,13 @@ export interface Toast<DataType> {
   /**Extra styles to apply for close button */
   closeStyle?: Record<string, string>;
 
+  /**
+   * Accessible label (`aria-label`) for the close button.
+   *
+   * @default 'Close'
+   */
+  closeLabel?: string;
+
   createdAt: number;
   visible: boolean;
   height?: number;
@@ -277,6 +285,7 @@ export type ToastOptions<DataType> = Partial<
     | 'theme'
     | 'position'
     | 'closeStyle'
+    | 'closeLabel'
     | 'persist'
     | 'injector'
     | 'data'
@@ -331,6 +340,7 @@ export type UpdateToastOptions<DataType> = Partial<
     | 'type'
     | 'theme'
     | 'closeStyle'
+    | 'closeLabel'
   >
 >;
 


### PR DESCRIPTION
Fixes #200.

### Problem

The close button's accessible name was hardcoded English and could not be configured, so screen readers announced "Close" regardless of the application's locale:

```html
<button class="hot-toast-close-btn" aria-label="Close" [style]="toast.closeStyle"></button>
```

There was no supported override — `closeStyle` is style-only, per-toast `attributes` are applied to `.hot-toast-bar-base` (not the button), and the button has no text content, so the `aria-label` is its entire accessible name.

### Change

Adds a `closeLabel` option, mirroring the existing `closeStyle` in every place it's declared:

- `ToastConfig.closeLabel = 'Close'` — the default, so behaviour is identical for existing users.
- `Toast.closeLabel?: string` with a documented `@default 'Close'`.
- `'closeLabel'` added to the `ToastOptions` and `UpdateToastOptions` pick lists (so it's settable per toast and via `updateToast`).
- Both templates (`hot-toast` and `hot-toast-group-item`) bind `[attr.aria-label]="toast.closeLabel"`.

Usage:

```ts
// globally
provideHotToastConfig({ closeLabel: 'Lukk' });
// or per toast
toast.success('Lagret', { closeLabel: 'Lukk' });
```

### Verification

`npm run build:lib` passes (Angular AOT compiles the new binding). In the built output I confirmed `ToastConfig` carries `closeLabel = 'Close'` and the template emits `[attr.aria-label]="toast.closeLabel"`. With no option set, the rendered button is `aria-label="Close"` exactly as before.
